### PR TITLE
datastructures: infinite recursion fix

### DIFF
--- a/invenio_utils/datastructures.py
+++ b/invenio_utils/datastructures.py
@@ -221,7 +221,7 @@ class SmartDict(object):
                 >>> %timeit x = dd['a'][0]['b']
                 1000000 loops, best of 3: 598 ns per loop
         """
-        def getitem(k, v):
+        def getitem(k, v, first=True):
             if isinstance(v, dict):
                 return v[k]
             elif ']' in k:
@@ -234,11 +234,13 @@ class SmartDict(object):
                         lambda x: int(x.strip()) if x.strip() else None,
                         k.split(':')
                     ))]
+            elif not first:
+                raise KeyError
             else:
                 tmp = []
                 for inner_v in v:
                     try:
-                        tmp.append(getitem(k, inner_v))
+                        tmp.append(getitem(k, inner_v, first=False))
                     except KeyError:
                         continue
                 return tmp

--- a/tests/test_utils_datastructures.py
+++ b/tests/test_utils_datastructures.py
@@ -238,6 +238,9 @@ class TestSmartDict(InvenioTestCase):
         d.set('a.b.c', ['foo'], False)
         self.assertEqual(d['a.b.c'], ['foo'])
 
+        d = SmartDict({'top': ['1', '2']})
+        self.assertEqual(d.get('top.doesnotexist'), [])
+
     def test_smart__contains(self):
         d = SmartDict()
 


### PR DESCRIPTION
- FIX Avoids infinite recursion when using `SmartDict.get` in
  certain cases.
- Amends test for this cases

Signed-off-by: Jan Aage Lavik jan.age.lavik@cern.ch
