### PR TITLE
date: output format parameter addition

### DIFF
--- a/invenio_utils/date.py
+++ b/invenio_utils/date.py
@@ -148,14 +148,13 @@ def convert_datetext_to_datestruct(datetext):
         return datestruct_default
 
 
-def convert_datestruct_to_dategui(datestruct, ln=None):
+def convert_datestruct_to_dategui(datestruct, ln=None, output_format="d MMM Y, H:mm"):
     """Convert: (2005, 11, 16, 15, 11, 44, 2, 320, 0) => '16 nov 2005, 15:11'
     Month is internationalized
     """
     assert ln is None, 'setting language is not supported'
     try:
         if datestruct[0] and datestruct[1] and datestruct[2]:
-            output_format = "d MMM Y, H:mm"
             dt = datetime.fromtimestamp(time.mktime(datestruct))
             return babel_format_datetime(dt, output_format)
         else:

--- a/invenio_utils/version.py
+++ b/invenio_utils/version.py
@@ -28,4 +28,4 @@ This file is imported by ``invenio_utils.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.2.1.dev20160116"
+__version__ = "0.2.1.dev20160210"


### PR DESCRIPTION
- Adds new output_format parameter to convert_datestruct_to_dategui
  function.
- Bumps version to 0.2.1.dev20160210.

Signed-off-by: Javier Martin Montull javier.martin.montull@cern.ch
